### PR TITLE
Introduces new XML schema to model the spatial boundary of ...

### DIFF
--- a/vip_spec.xsd
+++ b/vip_spec.xsd
@@ -383,7 +383,7 @@
     <xs:sequence>
       <xs:element name="ExternalFileId" type="xs:IDREF" />
       <xs:element name="FileFormat" type="GeospatialFormat" />
-      <xs:element name="ShapeIndex" type="xs:integer" maxOccurs="unbounded" />
+      <xs:element name="ShapeIdentifier" type="xs:string" maxOccurs="unbounded" />
     </xs:sequence>
   </xs:complexType>
 

--- a/vip_spec.xsd
+++ b/vip_spec.xsd
@@ -367,7 +367,6 @@
       <xs:element name="Number" type="xs:integer" minOccurs="0" />
       <xs:element name="Type" type="DistrictType" />
       <xs:element name="OtherType" type="xs:string" minOccurs="0" />
-      <xs:element name="SpatialBoundary" type="SpatialBoundary" minOccurs="0" />
     </xs:sequence>
     <xs:attribute name="id" type="xs:ID" use="required" />
   </xs:complexType>
@@ -610,6 +609,7 @@
       <xs:element name="Number" type="xs:string" minOccurs="0" maxOccurs="1" />
       <xs:element name="PollingLocationIds" type="xs:IDREFS" minOccurs="0" />
       <xs:element name="PrecinctSplitName" type="xs:string" minOccurs="0" maxOccurs="1" />
+      <xs:element name="SpatialBoundary" type="SpatialBoundary" minOccurs="0" />
       <xs:element name="Ward" type="xs:string" minOccurs="0" maxOccurs="1" />
     </xs:sequence>
     <xs:attribute name="id" type="xs:ID" use="required" />

--- a/vip_spec.xsd
+++ b/vip_spec.xsd
@@ -35,6 +35,13 @@
     </xs:restriction>
   </xs:simpleType>
 
+  <xs:simpleType name="ChecksumAlgorithm">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="sha-256" />
+      <xs:enumeration value="sha-512" />
+    </xs:restriction>
+  </xs:simpleType>
+
   <xs:simpleType name="DistrictType">
     <xs:restriction base="xs:string">
       <xs:enumeration value="borough" />
@@ -252,6 +259,13 @@
     </xs:complexContent>
   </xs:complexType>
 
+  <xs:complexType name="Checksum">
+    <xs:sequence>
+      <xs:element name="Algorithm" type="ChecksumAlgorithm" />
+      <xs:element name="Value" type="xs:string" />
+    </xs:sequence>
+  </xs:complexType>
+
   <xs:complexType name="ContactInformation">
     <xs:sequence>
       <xs:element name="AddressLine" type="xs:string" minOccurs="0" maxOccurs="unbounded" />
@@ -361,7 +375,7 @@
   <xs:complexType name="ExternalFile">
     <xs:sequence>
       <xs:element name="Filename" type="xs:string" />
-      <xs:element name="Sha256Sum" type="xs:string" />
+      <xs:element name="Checksum" type="Checksum" />
     </xs:sequence>
     <xs:attribute name="id" type="xs:ID" use="required" />
   </xs:complexType>

--- a/vip_spec.xsd
+++ b/vip_spec.xsd
@@ -61,6 +61,12 @@
     </xs:restriction>
   </xs:simpleType>
 
+  <xs:simpleType name="GeospatialFormat">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="shp" />
+   </xs:restriction>
+  </xs:simpleType>
+
   <xs:simpleType name="IdentifierType">
     <xs:restriction base="xs:string">
       <xs:enumeration value="fips" />
@@ -347,8 +353,25 @@
       <xs:element name="Number" type="xs:integer" minOccurs="0" />
       <xs:element name="Type" type="DistrictType" />
       <xs:element name="OtherType" type="xs:string" minOccurs="0" />
+      <xs:element name="SpatialBoundary" type="SpatialBoundary" minOccurs="0" />
     </xs:sequence>
     <xs:attribute name="id" type="xs:ID" use="required" />
+  </xs:complexType>
+
+  <xs:complexType name="ExternalFile">
+    <xs:sequence>
+      <xs:element name="Filename" type="xs:string" />
+      <xs:element name="Sha256Sum" type="xs:string" />
+    </xs:sequence>
+    <xs:attribute name="id" type="xs:ID" use="required" />
+  </xs:complexType>
+
+  <xs:complexType name="ExternalGeospatialFeature">
+    <xs:sequence>
+      <xs:element name="ExternalFileId" type="xs:IDREF" />
+      <xs:element name="FileFormat" type="GeospatialFormat" />
+      <xs:element name="ShapeIndex" type="xs:integer" maxOccurs="unbounded" />
+    </xs:sequence>
   </xs:complexType>
 
   <xs:complexType name="ExternalIdentifiers">
@@ -600,6 +623,14 @@
     </xs:sequence>
   </xs:complexType>
 
+  <xs:complexType name="SpatialBoundary">
+    <xs:sequence>
+      <xs:choice>
+        <xs:element name="ExternalGeospatialFeature" type="ExternalGeospatialFeature" />
+      </xs:choice>
+    </xs:sequence>
+  </xs:complexType>
+
   <xs:complexType name="State">
     <xs:sequence>
       <xs:element name="ElectionAdministrationId" type="xs:IDREF" minOccurs="0" />
@@ -683,6 +714,8 @@
         <xs:element name="ElectionAdministration" type="ElectionAdministration" />
 
         <xs:element name="ElectoralDistrict" type="ElectoralDistrict" />
+
+        <xs:element name="ExternalFile" type="ExternalFile" />
 
         <xs:element name="HoursOpen" type="HoursOpen" />
 

--- a/vip_spec.xsd
+++ b/vip_spec.xsd
@@ -71,7 +71,7 @@
   <xs:simpleType name="GeospatialFormat">
     <xs:restriction base="xs:string">
       <xs:enumeration value="shp" />
-   </xs:restriction>
+    </xs:restriction>
   </xs:simpleType>
 
   <xs:simpleType name="IdentifierType">


### PR DESCRIPTION
... Precincts using externally referenced files.

**_More context and detail available at https://github.com/votinginfoproject/vip-specification/issues/412._**

Summary of the XSD changes in this PR:
- Adds a new **ExternalFile** element, which contains two fields:
  - **FIlename**: The filename of the external geospatial file. This file would need to be distributed alongside the XML feed.
  - **Checksum**: The checksum for the external file of type **Checksum**. This checksum is required and serves a few purposes. First, it ensures that the correct version of the external file is used. Second, it allows for optimization by not having to reprocess external files which are unchanged since last processing.
- Adds a new **Checksum** element, which contains two fields:
  - **Value**: A string containing the checksum value
  - **Algorithm**: The type of checksum algorithm used to compute the value. This field is of type **ChecksumAlgorithm**.
- Adds a new _simpleType_ enumeration called **ChecksumAlgorithm** to capture the supported algorithms for computing checksums. I propose this initially only includes support for the two following algorithms:
  - sha-256
  - sha-512
- Adds a new **ExternalGeospatialFeature** element, which serves as a reference to one or more shapes in a separate file external to the XML. This element contains three fields:
  - **ExternalFileId**: an _xs:IDREF_ reference to the **ExternalFile** containing geospatial data
  - **FileFormat**: the open specification format for the geospatial data file, which is of type **GeospatialFormat**
  - **ShapeIdentifier**: A repeated field indicating which shape(s) to use from the geospatial file. It’s reasonable to expect that a single geospatial file would  contain many related shapes (i.e. the shapes for every precinct in a state), therefore this field provides a way to select a subset of all the shapes in the file.
- Adds a new _simpleType_ enumeration called **GeospatialFormat**, which represents the open geospatial formats supported. I propose that initially this only includes support for one format:
  - **shp**: The ESRI shapefile format, which is by far the most commonly used format for representing geospatial shape data.
- Adds a new **SpatialBoundary** element for defining a boundary. This element is a newly added field of the existing **Precinct** element, and has just one field for now:
  - **ExternalGeospatialFeature**: the geospatial feature that defines the spatial boundary. Note that this field is wrapped in an _xs:choice_ in the event we want to support other forms of geospatial modeling in the future, in which case the spatial boundary is defined by one of multiple options.